### PR TITLE
fixes for fribdaq

### DIFF
--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(mini-daq)
 add_subdirectory(mvlc-ctrl-tests)
 add_subdirectory(dev-tools)
 add_subdirectory(mvlc-cli)
+add_subdirectory(fribdaq)
 
 if (UNIX AND NOT APPLE)
     add_executable(netlink-test netlink-socket-mem-monitoring/netlink-test.cc)

--- a/extras/dev-tools/mvlc_init_daq_repeat.cc
+++ b/extras/dev-tools/mvlc_init_daq_repeat.cc
@@ -1,13 +1,12 @@
 #include <mesytec-mvlc/mesytec-mvlc.h>
 #include <argh.h>
-#include <signal.h>
 #include <system_error>
 
 using namespace mesytec::mvlc;
 
 int main(int argc, char *argv[])
 {
-    setup_signal_handlers();
+    util::setup_signal_handlers();
 
     spdlog::set_level(spdlog::level::info);
     mesytec::mvlc::set_global_log_level(spdlog::level::info);
@@ -70,7 +69,7 @@ int main(int argc, char *argv[])
         size_t cycleNumber = 0;
         size_t lastCycleNumber = 0;
 
-        while (!signal_received())
+        while (!util::signal_received())
         {
             auto initResults = init_readout(mvlc, crateConfig, {});
 

--- a/extras/dev-tools/mvlc_register_rw_loop.cc
+++ b/extras/dev-tools/mvlc_register_rw_loop.cc
@@ -165,14 +165,14 @@ int main(int argc, char *argv[])
     u16 registerAddress = 0x600E; // fw revision register. no effect when written to
     if (parser("--register-address") >> str)
     {
-        if (auto val = parse_unsigned<u16>(str))
+        if (auto val = util::parse_unsigned<u16>(str))
             registerAddress = *val;
     }
 
     u32 registerValue = 1;
     if (parser("--register-value") >> str)
     {
-        if (auto val = parse_unsigned<u32>(str))
+        if (auto val = util::parse_unsigned<u32>(str))
             registerValue = *val;
     }
 

--- a/extras/fribdaq/CMakeLists.txt
+++ b/extras/fribdaq/CMakeLists.txt
@@ -1,0 +1,8 @@
+#cmake_minimum_required(VERSION 3.13)
+#project(fribdaq-readout)
+
+# NSCLDAQ_ROOT  - defines where the NSCLDAQ software is installed
+# MVLC_ROOT     - Defines where the Mesytec mvlc software is installed.
+
+
+add_subdirectory(src)

--- a/extras/fribdaq/src/CMakeLists.txt
+++ b/extras/fribdaq/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 set(NSCLDAQ_ROOT "_"  CACHE STRING "_")
-set(NSCLDAQ_INC ${NSCLDAQ_ROOT}/include CACHE STRING "${NSCLDAQ_ROOT}/include")
-set(NSCLDAQ_LIB ${NSCLDAQ_ROOT}/lib CACHE STRING "${NSCLDAQ_ROOT}/lib")
+
 
 # Only build any of this stuff if NSCLDAQ_ROOT has been defined.
 # 
@@ -9,6 +8,7 @@ set(NSCLDAQ_LIB ${NSCLDAQ_ROOT}/lib CACHE STRING "${NSCLDAQ_ROOT}/lib")
 if (NSCLDAQ_ROOT STREQUAL "_")    # not defined.
     
 else ()
+    
     add_executable(fribdaq-readout 
     fribdaq_readout.cc
     command_parse.cc
@@ -17,12 +17,15 @@ else ()
     target_include_directories(
         fribdaq-readout PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${NSCLDAQ_INC}
+        ${NSCLDAQ_ROOT}/include
     )
     target_link_libraries(fribdaq-readout
         PRIVATE mesytec-mvlc
         PRIVATE BFG::Lyra
         PRIVATE spdlog::spdlog
+        PRIVATE ${NSCLDAQ_ROOT}/lib/libdaqshm.so
+        PRIVATE ${NSCLDAQ_ROOT}/lib/libDataFlow.so
+        PRIVATE ${NSCLDAQ_ROOT}/lib/libException.so
     )    
     install(TARGETS fribdaq-readout)
 

--- a/extras/fribdaq/src/CMakeLists.txt
+++ b/extras/fribdaq/src/CMakeLists.txt
@@ -13,6 +13,7 @@ else ()
     fribdaq_readout.cc
     command_parse.cc
     username.cc
+    parser_callbacks.cc
     )
     target_include_directories(
         fribdaq-readout PRIVATE
@@ -23,6 +24,8 @@ else ()
         PRIVATE mesytec-mvlc
         PRIVATE BFG::Lyra
         PRIVATE spdlog::spdlog
+        PRIVATE ${NSCLDAQ_ROOT}/lib/libdataformat.so
+        PRIVATE ${NSCLDAQ_ROOT}/lib/liburl.so
         PRIVATE ${NSCLDAQ_ROOT}/lib/libdaqshm.so
         PRIVATE ${NSCLDAQ_ROOT}/lib/libDataFlow.so
         PRIVATE ${NSCLDAQ_ROOT}/lib/libException.so

--- a/extras/fribdaq/src/CMakeLists.txt
+++ b/extras/fribdaq/src/CMakeLists.txt
@@ -3,6 +3,9 @@ set(NSCLDAQ_ROOT "_"  CACHE STRING "_")
 set(NSCLDAQ_INC ${NSCLDAQ_ROOT}/include CACHE STRING "${NSCLDAQ_ROOT}/include")
 set(NSCLDAQ_LIB ${NSCLDAQ_ROOT}/lib CACHE STRING "${NSCLDAQ_ROOT}/lib")
 
+# Only build any of this stuff if NSCLDAQ_ROOT has been defined.
+# 
+
 if (NSCLDAQ_ROOT STREQUAL "_")    # not defined.
     set(exclusion_patterns PATTERN fribdaq-readout EXCLUDE)
 else ()

--- a/extras/fribdaq/src/CMakeLists.txt
+++ b/extras/fribdaq/src/CMakeLists.txt
@@ -7,9 +7,17 @@ set(NSCLDAQ_LIB ${NSCLDAQ_ROOT}/lib CACHE STRING "${NSCLDAQ_ROOT}/lib")
 # 
 
 if (NSCLDAQ_ROOT STREQUAL "_")    # not defined.
-    set(exclusion_patterns PATTERN fribdaq-readout EXCLUDE)
+    
 else ()
-    add_executable(fribdaq-readout fribdaq_readout.cc)
+    add_executable(fribdaq-readout 
+    fribdaq_readout.cc
+    command_parse.cc
+    )
+    target_include_directories(
+        fribdaq-readout PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${NSCLDAQ_INC}
+    )
     target_link_libraries(fribdaq-readout
         PRIVATE mesytec-mvlc
         PRIVATE BFG::Lyra

--- a/extras/fribdaq/src/CMakeLists.txt
+++ b/extras/fribdaq/src/CMakeLists.txt
@@ -24,6 +24,15 @@ else ()
         PRIVATE spdlog::spdlog
     )    
     install(TARGETS fribdaq-readout)
+
+    # Tests:
+
+    add_executable(parse_test parse_test.cc command_parse.cc)
+    target_link_libraries(parse_test
+            PRIVATE gtest
+            PRIVATE gtest_main
+    )
+    add_test(NAME parse_test COMMAND parse_test)
 endif ()
 
 

--- a/extras/fribdaq/src/CMakeLists.txt
+++ b/extras/fribdaq/src/CMakeLists.txt
@@ -12,6 +12,7 @@ else ()
     add_executable(fribdaq-readout 
     fribdaq_readout.cc
     command_parse.cc
+    username.cc
     )
     target_include_directories(
         fribdaq-readout PRIVATE

--- a/extras/fribdaq/src/CMakeLists.txt
+++ b/extras/fribdaq/src/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+set(NSCLDAQ_ROOT "_"  CACHE STRING "_")
+set(NSCLDAQ_INC ${NSCLDAQ_ROOT}/include CACHE STRING "${NSCLDAQ_ROOT}/include")
+set(NSCLDAQ_LIB ${NSCLDAQ_ROOT}/lib CACHE STRING "${NSCLDAQ_ROOT}/lib")
+
+if (NSCLDAQ_ROOT STREQUAL "_")    # not defined.
+    set(exclusion_patterns PATTERN fribdaq-readout EXCLUDE)
+else ()
+    add_executable(fribdaq-readout fribdaq_readout.cc)
+    target_link_libraries(fribdaq-readout
+        PRIVATE mesytec-mvlc
+        PRIVATE BFG::Lyra
+        PRIVATE spdlog::spdlog
+    )    
+    install(TARGETS fribdaq-readout)
+endif ()
+
+
+

--- a/extras/fribdaq/src/CMakeLists.txt
+++ b/extras/fribdaq/src/CMakeLists.txt
@@ -29,7 +29,10 @@ else ()
         PRIVATE ${NSCLDAQ_ROOT}/lib/libdaqshm.so
         PRIVATE ${NSCLDAQ_ROOT}/lib/libDataFlow.so
         PRIVATE ${NSCLDAQ_ROOT}/lib/libException.so
-    )    
+    )  
+    target_link_options(fribdaq-readout PRIVATE
+        -Wl,-rpath=${NSCLDAQ_ROOT}/lib
+    )  
     install(TARGETS fribdaq-readout)
 
     # Tests:

--- a/extras/fribdaq/src/command_parse.cc
+++ b/extras/fribdaq/src/command_parse.cc
@@ -53,7 +53,7 @@ trim(std::string& str) {
     return result;
 }
 /*  True if the parameter is a string that is only whitespace */
-static bool
+bool
 isBlank(const std::string& str) {
     return std::all_of(str.begin(), str.end(), isspace);
 }

--- a/extras/fribdaq/src/command_parse.cc
+++ b/extras/fribdaq/src/command_parse.cc
@@ -5,7 +5,7 @@
  * 
  *
  *   This software is Copyright by the Board of Trustees of Michigan
- *   State University (c) Copyright 2005.
+ *   State University (c) Copyright 2025.
  *
  *   You may use this software under the terms of the GNU public license
  *   (GPL).  The terms of this license are described at:

--- a/extras/fribdaq/src/command_parse.cc
+++ b/extras/fribdaq/src/command_parse.cc
@@ -1,0 +1,98 @@
+/**
+ * @file command_parse.cc
+ * @brief interface for stupid command parser.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2005.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout 
+ * @note - this is  extracted from fribdaq_readout.cc to allow unit tests to be run
+ * against it.
+ */
+#include "command_parse.h"
+#include <sstream>
+#include <algorithm>
+#include <ctype.h>
+#include <map>
+
+// Map between command words and enum
+static std::map<std::string, StdinCommands> commandMap = {
+    {"BEGIN", BEGIN}, 
+    {"END", END}, 
+    {"PAUSE", PAUSE}, 
+    {"RESUME", RESUME},
+    {"TITLE", TITLE},  // Remainder of line is a title. 
+    {"SETRUN", SETRUN} // Remainder of line is a + integer run number.
+};
+
+/*  True if the parameter is a string that is only whitespace */
+static bool
+isBlank(const std::string& str) {
+    return std::all_of(str.begin(), str.end(), isspace);
+}
+/*
+ *  parseCommand implementation.
+ */
+ParsedCommand
+parseCommand(const std::string& line) {
+    ParsedCommand parsed;
+
+    // Get the command word and map it to a command value:
+
+    std::stringstream words(line); 
+    std::string commandword;
+    std::string remainder;
+    words >> commandword;
+    if (commandMap.find(commandword) == commandMap.end()) {
+        parsed.s_error ="Invalid command keyword";
+        // invalid (empty goes here too):
+        return parsed;   //   Initializes to invalid
+    }
+    parsed.s_command = commandMap[commandword];
+    std::getline(words, remainder);
+    switch (parsed.s_command) {
+    case BEGIN:
+    case END:                           // These should have at most a whitespace remainder:
+    case PAUSE:
+    case RESUME:
+        if (!isBlank(remainder)) {
+            parsed.s_command = INVALID;
+            parsed.s_error = "Unexpected characters following the command keyword";
+        }
+        break;
+    case TITLE:                        // Remainder is the arg.
+        parsed.s_stringarg = remainder;
+        break;
+    case SETRUN:                      // Remainder is a postitive integer.
+        if (!words >> parsed.s_intarg) {
+            parsed.s_command = INVALID;
+            parsed.s_error = "SETRUN needs a run number";
+        } else {
+            // Run must be > 0:
+
+            if (parsed.s_intarg <= 0) {
+                parsed.s_command = INVALID;
+                parsed.s_error = "SETRUN's run number must be > 0";
+            } else {
+                // The remainder now must be empty:
+
+                getline(words, remainder);
+                if (!isBlank(remainder)) {
+                    parsed.s_command = INVALID;
+                    parsed.s_error = "Unexpected characters following the command keyword";
+                }
+            }
+        }
+    default:                                      // Error to land here:
+        parsed.s_command = INVALID;
+        parsed.s_error = "The command parser has an error and took a case it should not have";
+    }
+    return parsed;
+}

--- a/extras/fribdaq/src/command_parse.h
+++ b/extras/fribdaq/src/command_parse.h
@@ -5,7 +5,7 @@
  * 
  *
  *   This software is Copyright by the Board of Trustees of Michigan
- *   State University (c) Copyright 2005.
+ *   State University (c) Copyright 2025.
  *
  *   You may use this software under the terms of the GNU public license
  *   (GPL).  The terms of this license are described at:

--- a/extras/fribdaq/src/command_parse.h
+++ b/extras/fribdaq/src/command_parse.h
@@ -1,0 +1,58 @@
+/**
+ * @file command_parse.h
+ * @brief interface for stupid command parser.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2005.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#ifndef COMMAND_PARSE_H
+#define COMMAND_PARSE_H
+#include <string>
+
+
+/* @todo - hide this in a namespace?  Maye not because its private?*/
+/** Parsed command values. from stdin.
+ * 
+ */
+typedef enum _StdinCommands  {
+    BEGIN, END, PAUSE, RESUME, TITLE, SETRUN, INVALID
+} StdinCommands;
+
+/**
+ * The parser produces a ParsedCommand struct.
+ * -  s_command is the command keyword.
+ * -  For TITLE, s_stringarg is the actual title string.
+ * -  For SETRUN s_intarg is the run number provided.
+ * -  s_error -for INVALID is the textual parse error.
+ */
+struct ParsedCommand {
+    StdinCommands s_command;
+    std::string   s_stringarg;
+    int         s_intarg;
+    std::string   s_error;
+ParsedCommand()  :
+    s_command(INVALID) {}
+
+};
+
+/**
+ * parseCommand:
+ *  Take a command line and parse it into a ParsedCommand
+ *   @param[in] line - input line string.
+ *   @return ParsedCommand
+ *   @retval if .s_command is INVALID, the parse failed for any
+ * of a number of reasons that are in .s_error
+ */
+ParsedCommand
+parseCommand(const std::string& line);
+
+#endif

--- a/extras/fribdaq/src/command_parse.h
+++ b/extras/fribdaq/src/command_parse.h
@@ -37,13 +37,19 @@ typedef enum _StdinCommands  {
 struct ParsedCommand {
     StdinCommands s_command;
     std::string   s_stringarg;
-    int         s_intarg;
+    int           s_intarg;
     std::string   s_error;
 ParsedCommand()  :
     s_command(INVALID) {}
 
 };
 
+/**
+ *  @param[in] s - string to test.
+ *  @return bool - true if s only consists of whitespace.
+ */
+bool
+isBlank(const std::string& s);
 /**
  * parseCommand:
  *  Take a command line and parse it into a ParsedCommand

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -638,7 +638,7 @@ int main(int argc, char *argv[])
             // If we are active, count a second:
 
             if (ExtraRunState.s_runState == Active) {
-                ExtraRunState. s_runtime += 1;                          // one second has passed.
+                ExtraRunState. s_runtime += 1000;                          // one second has passed.
             }
 
             if (stdinPending()) {                    // Process commands.

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -639,7 +639,7 @@ int main(int argc, char *argv[])
             // If we are active, count a second:
 
             if (ExtraRunState.s_runState == Active) {
-                ExtraRunState. s_runtime += 1000;                          // one second has passed.
+                ExtraRunState. s_runtime += 1;                          // one second has passed.
             }
 
             if (stdinPending()) {                    // Process commands.
@@ -691,6 +691,7 @@ int main(int argc, char *argv[])
                             } else {
                                 std::cerr << " Run state does not allow us to pause a run\n";
                             }
+                            break;
                         case RESUME:
                             if (canResume(rdo)) {
                                 spdlog::info("Resuming paused run");

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -149,10 +149,9 @@ canPause(MVLCReadout& rdo) {
  */
 static bool
 canResume(MVLCReadout& rdo) {
-    return (
-        (ExtraRunState.s_runState == Paused)
-        && rdo.finished()
-    );
+    return 
+        (ExtraRunState.s_runState == Paused);
+    
 }
 /////////////////////
 StackErrorCounters delta_counters(const StackErrorCounters &prev, const StackErrorCounters &curr)

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -618,7 +618,9 @@ int main(int argc, char *argv[])
             mvlc,
             crateConfig,
             listfileParams,
-            parserCallbacks);
+            parserCallbacks,
+            &ExtraRunState
+        );
 #ifdef AUTO_START                              // Start from commands.
         spdlog::info("Starting readout. Running for {} seconds.", timeToRun.count());
 

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <cstdlib>
 #include "command_parse.h"
+#include "username.h"
 #ifdef __WIN32
 #include <stdlib.h> // system()
 #endif
@@ -416,6 +417,7 @@ int main(int argc, char *argv[])
     bool opt_logTrace = false;
     bool opt_initOnly = false;
     bool opt_ignoreInitErrors = false;
+    std::string opt_ringBufferName = getUsername();
 
     auto cli
         = lyra::help(opt_showHelp)
@@ -461,11 +463,11 @@ int main(int argc, char *argv[])
 
         | lyra::opt(opt_ignoreInitErrors)
             ["--ignore-vme-init-errors"]("ignore VME errors during the DAQ init sequence")
-
+        | lyra::opt(opt_ringBufferName, "ring")["--ring"]("ring buffer name")
         // logging
         | lyra::opt(opt_logDebug)["--debug"]("enable debug logging")
         | lyra::opt(opt_logTrace)["--trace"]("enable trace logging")
-
+        
         // positional args
         | lyra::arg(opt_crateConfig, "crateConfig")
             ("crate config yaml file").required()
@@ -473,6 +475,7 @@ int main(int argc, char *argv[])
         | lyra::arg(opt_secondsToRun, "secondsToRun")
             ("duration the DAQ should run in seconds").optional()
 #endif
+        
         ;
 
     auto cliParseResult = cli.parse({ argc, argv });

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -1,0 +1,592 @@
+#include <chrono>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <thread>
+#include <vector>
+#include <fstream>
+
+#ifdef __WIN32
+#include <stdlib.h> // system()
+#endif
+
+#include <mesytec-mvlc/mesytec-mvlc.h>
+#include <lyra/lyra.hpp>
+
+using std::cout;
+using std::cerr;
+using std::endl;
+
+using namespace mesytec::mvlc;
+
+struct MiniDaqCountersSnapshot
+{
+    StackErrorCounters mvlcStackErrors;
+    ReadoutWorker::Counters readoutWorkerCounters;
+    readout_parser::ReadoutParserCounters parserCounters;
+};
+
+StackErrorCounters delta_counters(const StackErrorCounters &prev, const StackErrorCounters &curr)
+{
+    StackErrorCounters result;
+
+    std::transform(std::begin(prev.stackErrors), std::end(prev.stackErrors),
+                   std::begin(curr.stackErrors),
+                   std::begin(result.stackErrors),
+                   util::delta_map<ErrorInfoCounts>);
+
+    result.nonErrorFrames = calc_delta0(curr.nonErrorFrames, prev.nonErrorFrames);
+    result.nonErrorHeaderCounts = delta_map(prev.nonErrorHeaderCounts, curr.nonErrorHeaderCounts);
+
+    return result;
+}
+
+#define CALC_DELTA0(member) result.member = calc_delta0(curr.member, prev.member)
+
+ReadoutWorker::Counters delta_counters(const ReadoutWorker::Counters &prev, const ReadoutWorker::Counters &curr)
+{
+    ReadoutWorker::Counters result;
+
+    CALC_DELTA0(buffersRead);
+    CALC_DELTA0(buffersFlushed);
+    CALC_DELTA0(bytesRead);
+    CALC_DELTA0(snoopMissedBuffers);
+    CALC_DELTA0(usbFramingErrors);
+    CALC_DELTA0(usbTempMovedBytes);
+    CALC_DELTA0(ethShortReads);
+    CALC_DELTA0(readTimeouts);
+
+    std::transform(std::begin(prev.stackHits), std::end(prev.stackHits),
+                   std::begin(curr.stackHits),
+                   std::begin(result.stackHits),
+                   calc_delta0<size_t>);
+
+    // TODO eth::PipeStats
+    // TODO ListfileWriterCounters
+
+    return result;
+}
+
+MiniDaqCountersSnapshot delta_counters(const MiniDaqCountersSnapshot &prev, const MiniDaqCountersSnapshot &curr)
+{
+    MiniDaqCountersSnapshot result;
+
+    result.mvlcStackErrors = delta_counters(prev.mvlcStackErrors, curr.mvlcStackErrors);
+    result.readoutWorkerCounters = delta_counters(prev.readoutWorkerCounters, curr.readoutWorkerCounters);
+    // TODO: result.parserCounters = delta_counters(prev.parserCounters, curr.parserCounters);
+
+    return result;
+}
+
+#undef CALC_DELTA0
+
+
+struct MiniDaqCountersUpdate
+{
+    MiniDaqCountersSnapshot prev;
+    MiniDaqCountersSnapshot curr;
+    std::chrono::milliseconds dt;
+};
+
+void dump_counters2(
+    std::ostream &out,
+    const MiniDaqCountersSnapshot &prev,
+    const MiniDaqCountersSnapshot &curr,
+    const std::chrono::milliseconds &dt)
+{
+    auto delta = delta_counters(prev, curr);
+
+    out << fmt::format("dt={} ms, dBytesRead={} B, {} MiB, readRate={} B/s, {}MiB/s\n",
+                       dt.count(),
+                       delta.readoutWorkerCounters.bytesRead,
+                       delta.readoutWorkerCounters.bytesRead / 1024.0 / 1024.0,
+                       static_cast<double>(delta.readoutWorkerCounters.bytesRead) / (dt.count() / 1000.0),
+                       static_cast<double>(delta.readoutWorkerCounters.bytesRead) / 1024.0 / 1024.0 / (dt.count() / 1000.0));
+}
+
+void update_counters(MiniDaqCountersUpdate &counters, MVLCReadout &rdo, std::chrono::milliseconds dt)
+{
+    counters.prev = counters.curr;
+    auto &mvlc = rdo.readoutWorker().mvlc();
+    counters.curr.mvlcStackErrors = mvlc.getStackErrorCounters();
+    counters.curr.readoutWorkerCounters = rdo.workerCounters();
+    counters.curr.parserCounters = rdo.parserCounters();
+    counters.dt = dt;
+}
+
+void dump_counters(
+    std::ostream &out,
+    const ConnectionType &connectionType,
+    const StackErrorCounters &stackErrors,
+    const ReadoutWorker::Counters &readoutWorkerCounters,
+    const readout_parser::ReadoutParserCounters &parserCounters)
+{
+#if 0
+// clear screen hacks
+#ifdef __WIN32
+    system("cls");
+#else
+    out << "\e[1;1H\e[2J";
+#endif
+#endif
+    //
+    // readout stats
+    //
+    {
+        auto &counters = readoutWorkerCounters;
+
+        auto tStart = counters.tStart;
+        // Note: if idle this uses the tTerminateStart time point. This means
+        // the duration from counters.tStart to counters.tTerminateStart is
+        // used as the whole duration of the DAQ. This still does not correctly
+        // reflect the actual data rate because it does contains the
+        // bytes/packets/etc that where read during the terminate phase. It
+        // should be closer than using tEnd though as that will include at
+        // least one read timeout from the terminate procedure.
+        auto tEnd = (counters.state != ReadoutWorker::State::Idle
+                     ?  std::chrono::steady_clock::now()
+                     : counters.tTerminateStart);
+        auto runDuration = std::chrono::duration_cast<std::chrono::milliseconds>(tEnd - tStart);
+        double runSeconds = runDuration.count() / 1000.0;
+        double megaBytes = counters.bytesRead * 1.0 / util::Megabytes(1);
+        double mbs = megaBytes / runSeconds;
+
+        cout << endl;
+        cout << "---- readout stats ----" << endl;
+        cout << "buffersRead=" << counters.buffersRead << endl;
+        cout << "buffersFlushed=" << counters.buffersFlushed << endl;
+        cout << "snoopMissedBuffers=" << counters.snoopMissedBuffers << endl;
+        cout << "usbFramingErrors=" << counters.usbFramingErrors << endl;
+        cout << "usbTempMovedBytes=" << counters.usbTempMovedBytes << endl;
+        cout << "ethShortReads=" << counters.ethShortReads << endl;
+        cout << "readTimeouts=" << counters.readTimeouts << endl;
+        cout << "totalBytesTransferred=" << counters.bytesRead << endl;
+        cout << "duration=" << runDuration.count() << " ms" << endl;
+
+        cout << "stackHits: ";
+        for (size_t stack=0; stack<counters.stackHits.size(); ++stack)
+        {
+            size_t hits = counters.stackHits[stack];
+
+            if (hits)
+                cout << stack << ": " << hits << " ";
+        }
+        cout << endl;
+
+        cout << "stackErrors:";
+        for (size_t stack=0; stack<stackErrors.stackErrors.size(); ++stack)
+        {
+            const auto &errorCounts = stackErrors.stackErrors[stack];
+
+            for (auto it=errorCounts.begin(); it!=errorCounts.end(); ++it)
+            {
+                cout << fmt::format("stack={}, line={}, flags={}, count={}",
+                                    stack, it->first.line, it->first.flags,
+                                    it->second)
+                    << endl;
+            }
+        }
+
+        cout << endl;
+
+        if (connectionType == ConnectionType::ETH)
+        {
+            auto pipeCounters = counters.ethStats[DataPipe];
+            cout << endl;
+            cout << "  -- eth data pipe receive stats --" << endl;
+            cout << "  receiveAttempts=" << pipeCounters.receiveAttempts << endl;
+            cout << "  receivedPackets=" << pipeCounters.receivedPackets << endl;
+            cout << "  receivedBytes=" << pipeCounters.receivedBytes << endl;
+            cout << "  shortPackets=" << pipeCounters.shortPackets << endl;
+            cout << "  packetsWithResidue=" << pipeCounters.packetsWithResidue << endl;
+            cout << "  noHeader=" << pipeCounters.noHeader << endl;
+            cout << "  headerOutOfRange=" << pipeCounters.headerOutOfRange << endl;
+            cout << "  lostPackets=" << pipeCounters.lostPackets << endl;
+        }
+
+        cout << endl;
+
+        // listfile writer counters
+        {
+            auto writerCounters = counters.listfileWriterCounters;
+            auto tStart = writerCounters.tStart;
+            auto tEnd = (writerCounters.state != ListfileWriterCounters::Idle
+                         ? std::chrono::steady_clock::now()
+                         : writerCounters.tEnd);
+            auto writerElapsed = std::chrono::duration_cast<std::chrono::milliseconds>(tEnd - tStart);
+            auto writerSeconds = writerElapsed.count() / 1000.0;
+            double megaBytes = writerCounters.bytesWritten * 1.0 / util::Megabytes(1);
+            double mbs = megaBytes / writerSeconds;
+
+            cout << "  -- listfile writer counters --" << endl;
+            cout << "  writes=" << writerCounters.writes << endl;
+            cout << "  bytesWritten=" << writerCounters.bytesWritten << endl;
+            cout << "  exception=";
+            try
+            {
+                if (counters.eptr)
+                    std::rethrow_exception(counters.eptr);
+                cout << "none" << endl;
+            }
+            catch (const std::runtime_error &e)
+            {
+                cout << e.what() << endl;
+            }
+            cout << "  duration=" << writerSeconds << " s" << endl;
+            cout << "  rate=" << mbs << " MB/s" << endl;
+        }
+
+        cout << endl;
+
+        cout << "Ran for " << runSeconds << " seconds, transferred a total of " << megaBytes
+            << " MB, resulting data rate: " << mbs << "MB/s"
+            << endl;
+    }
+
+    //
+    // parser stats
+    //
+    {
+        cout << endl << "---- readout parser stats ----" << endl;
+        readout_parser::print_counters(cout, parserCounters);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    // MVLC connection overrides
+    std::string opt_mvlcEthHost;
+    bool opt_mvlcUseFirstUSBDevice = false;
+    int opt_mvlcUSBIndex = -1;
+    std::string opt_mvlcUSBSerial;
+
+    // listfile and run options
+    bool opt_noListfile = false;
+    bool opt_overwriteListfile = false;
+    std::string opt_listfileOut;
+    std::string opt_listfileCompressionType = "lz4";
+    int opt_listfileCompressionLevel = 0;
+    std::string opt_crateConfig;
+    unsigned opt_secondsToRun = 0;
+    bool opt_printReadoutData = false;
+    bool opt_noPeriodicCounterDumps = false;
+
+    bool opt_showHelp = false;
+    bool opt_logDebug = false;
+    bool opt_logTrace = false;
+    bool opt_initOnly = false;
+    bool opt_ignoreInitErrors = false;
+
+    auto cli
+        = lyra::help(opt_showHelp)
+
+        // mvlc overrides
+        | lyra::opt(opt_mvlcEthHost, "hostname")
+            ["--mvlc-eth"] ("mvlc ethernet hostname (overrides CrateConfig)")
+
+        | lyra::opt(opt_mvlcUseFirstUSBDevice)
+            ["--mvlc-usb"] ("connect to the first mvlc usb device (overrides CrateConfig)")
+
+        | lyra::opt(opt_mvlcUSBIndex, "index")
+            ["--mvlc-usb-index"] ("connect to the mvlc with the given usb device index (overrides CrateConfig)")
+
+        | lyra::opt(opt_mvlcUSBSerial, "serial")
+            ["--mvlc-usb-serial"] ("connect to the mvlc with the given usb serial number (overrides CrateConfig)")
+
+        // listfile
+        | lyra::opt(opt_noListfile)
+            ["--no-listfile"] ("do not write readout data to a listfile (data will not be recorded)")
+
+        | lyra::opt(opt_overwriteListfile)
+            ["--overwrite-listfile"] ("overwrite an existing listfile")
+
+        | lyra::opt(opt_listfileOut, "listfileName")
+            ["--listfile"] ("filename of the output listfile (e.g. run001.zip)")
+
+        | lyra::opt(opt_listfileCompressionType, "type")
+            ["--listfile-compression-type"].choices("zip", "lz4") ("'zip' or 'lz4'")
+
+        | lyra::opt(opt_listfileCompressionLevel, "level")
+            ["--listfile-compression-level"] ("compression level to use (for zip 0 means no compression)")
+
+        // logging
+        | lyra::opt(opt_printReadoutData)
+            ["--print-readout-data"]("log each word of readout data (very verbose!)")
+
+        | lyra::opt(opt_noPeriodicCounterDumps)
+            ["--no-periodic-counter-dumps"]("do not periodcally print readout and parser counters to stdout")
+
+        | lyra::opt(opt_initOnly)
+            ["--init-only"]("run the DAQ init sequence and exit")
+
+        | lyra::opt(opt_ignoreInitErrors)
+            ["--ignore-vme-init-errors"]("ignore VME errors during the DAQ init sequence")
+
+        // logging
+        | lyra::opt(opt_logDebug)["--debug"]("enable debug logging")
+        | lyra::opt(opt_logTrace)["--trace"]("enable trace logging")
+
+        // positional args
+        | lyra::arg(opt_crateConfig, "crateConfig")
+            ("crate config yaml file").required()
+
+        | lyra::arg(opt_secondsToRun, "secondsToRun")
+            ("duration the DAQ should run in seconds").optional()
+        ;
+
+    auto cliParseResult = cli.parse({ argc, argv });
+
+    if (!cliParseResult)
+    {
+        cerr << "Error parsing command line arguments: " << cliParseResult.errorMessage() << endl;
+        return 1;
+    }
+
+    if (opt_showHelp)
+    {
+        cout << cli << endl;
+
+        cout
+            << "The mini-daq utility is a command-line program for running a"
+            << " MVLC based DAQ." << endl << endl
+            << "Configuration data has to be supplied in a YAML 'CrateConfig' file." << endl
+            << "Such a config file can be generated from an mvme setup using the" << endl
+            << "'File -> Export VME Config' menu entry in mvme." << endl << endl
+            << "Alternatively a CrateConfig object can be generated programmatically and" << endl
+            << "written out using the to_yaml() free function."
+            << endl;
+        return 0;
+    }
+
+    // logging setup
+    if (opt_logDebug)
+        set_global_log_level(spdlog::level::debug);
+
+    if (opt_logTrace)
+        set_global_log_level(spdlog::level::trace);
+
+
+    std::ifstream inConfig(opt_crateConfig);
+
+    if (!inConfig.is_open())
+    {
+        cerr << "Error opening crate config " << argv[1] << " for reading." << endl;
+        return 1;
+    }
+
+    try
+    {
+        auto timeToRun = std::chrono::seconds(opt_secondsToRun);
+
+        CrateConfig crateConfig = {};
+
+        try
+        {
+            crateConfig = crate_config_from_yaml(inConfig);
+        }
+        catch (const std::runtime_error &e)
+        {
+            cerr << "Error parsing CrateConfig: " << e.what() << endl;
+            return 1;
+        }
+
+        MVLC mvlc;
+
+        if (!opt_mvlcEthHost.empty())
+            mvlc = make_mvlc_eth(opt_mvlcEthHost);
+        else if (opt_mvlcUseFirstUSBDevice)
+            mvlc = make_mvlc_usb();
+        else if (opt_mvlcUSBIndex >= 0)
+            mvlc = make_mvlc_usb(opt_mvlcUSBIndex);
+        else if (!opt_mvlcUSBSerial.empty())
+            mvlc = make_mvlc_usb(opt_mvlcUSBSerial);
+        else
+            mvlc = make_mvlc(crateConfig);
+
+        // Cancel any possibly running readout when connecting.
+        mvlc.setDisableTriggersOnConnect(true);
+
+        if (auto ec = mvlc.connect())
+        {
+            cerr << "Error connecting to MVLC: " << ec.message() << endl;
+            return 1;
+        }
+
+        CommandExecOptions initOptions{};
+        initOptions.continueOnVMEError = opt_ignoreInitErrors;
+
+        if (opt_initOnly)
+        {
+            cout << "Running DAQ init sequence and exiting.\n";
+            auto initResults = init_readout(mvlc, crateConfig, initOptions);
+
+            if (initResults.ec)
+                std::cerr << fmt::format("  Error during DAQ init sequence: {}\n", initResults.ec.message());
+
+            for (const auto &cmdResult: initResults.init)
+            {
+                if (cmdResult.ec)
+                {
+                    std::cerr << fmt::format("  Error during DAQ init sequence: cmd={}, ec={}\n",
+                        to_string(cmdResult.cmd), cmdResult.ec.message());
+                }
+            }
+
+            if (initResults.ec)
+                return opt_ignoreInitErrors ? 0 : 1;
+            return 0;
+        }
+
+        //cout << "Connected to MVLC " << mvlc.connectionInfo() << endl;
+
+        //
+        // Listfile setup
+        //
+        if (opt_listfileOut.empty())
+            opt_listfileOut = util::basename(opt_crateConfig) + ".zip";
+
+        ListfileParams listfileParams =
+        {
+            .writeListfile = !opt_noListfile,
+            .filepath = opt_listfileOut,
+            .overwrite = opt_overwriteListfile,
+
+            .compression = (opt_listfileCompressionType == "lz4"
+                            ? ListfileParams::Compression::LZ4
+                            : ListfileParams::Compression::ZIP),
+
+            .compressionLevel = opt_listfileCompressionLevel,
+
+        };
+
+        //
+        // readout parser callbacks
+        //
+
+        readout_parser::ReadoutParserCallbacks parserCallbacks;
+
+        parserCallbacks.eventData = [opt_printReadoutData] (
+            void *, int crateId, int eventIndex, const readout_parser::ModuleData *moduleDataList, unsigned moduleCount)
+        {
+            if (opt_printReadoutData)
+            {
+                for (u32 moduleIndex = 0; moduleIndex < moduleCount; ++moduleIndex)
+                {
+                    auto &moduleData = moduleDataList[moduleIndex];
+
+                    if (moduleData.data.size)
+                        util::log_buffer(
+                            std::cout, basic_string_view<u32>(moduleData.data.data, moduleData.data.size),
+                            fmt::format("module data: crateId={} eventIndex={}, moduleIndex={}", crateId, eventIndex, moduleIndex));
+                }
+            }
+        };
+
+        parserCallbacks.systemEvent = [opt_printReadoutData] (
+            void *, int crateId, const u32 *header, u32 size)
+        {
+            if (opt_printReadoutData)
+            {
+                std::cout
+                    << "SystemEvent: type=" << system_event_type_to_string(
+                        system_event::extract_subtype(*header))
+                    << ", size=" << size << ", bytes=" << (size * sizeof(u32))
+                    << endl;
+                fmt::print("system event: crateId={}, header={:08x}", crateId, *header);
+            }
+        };
+
+        //
+        // readout object
+        //
+
+        auto rdo = make_mvlc_readout(
+            mvlc,
+            crateConfig,
+            listfileParams,
+            parserCallbacks);
+
+        spdlog::info("Starting readout. Running for {} seconds.", timeToRun.count());
+
+        if (auto ec = rdo.start(timeToRun))
+        {
+            cerr << "Error starting readout: " << ec.message() << endl;
+            throw std::runtime_error("ReadoutWorker error");
+        }
+
+        MiniDaqCountersUpdate counters;
+        Stopwatch sw;
+
+        while (!rdo.finished())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+            if (!opt_noPeriodicCounterDumps)
+            {
+                dump_counters(
+                    cout,
+                    crateConfig.connectionType,
+                    mvlc.getStackErrorCounters(),
+                    rdo.workerCounters(),
+                    rdo.parserCounters());
+
+                update_counters(counters, rdo, std::chrono::duration_cast<std::chrono::milliseconds>(sw.interval()));
+                dump_counters2(cout, counters.prev, counters.curr, counters.dt);
+
+            }
+        }
+
+        mvlc.disconnect();
+
+        cout << endl << "Final stats dump:" << endl;
+
+        dump_counters(
+            cout,
+            crateConfig.connectionType,
+            mvlc.getStackErrorCounters(),
+            rdo.workerCounters(),
+            rdo.parserCounters());
+
+        update_counters(counters, rdo, std::chrono::duration_cast<std::chrono::milliseconds>(sw.interval()));
+        dump_counters2(cout, counters.prev, counters.curr, counters.dt);
+
+
+        auto cmdPipeCounters = mvlc.getCmdPipeCounters();
+
+        spdlog::debug("CmdPipeCounters:\n"
+                      "    reads={}, bytesRead={}, timeouts={}, invalidHeaders={}, wordsSkipped={}\n"
+                      "    errorBuffers={}, superBuffer={}, stackBuffers={}, dsoBuffers={}\n"
+                      "    shortSupers={}, superFormatErrors={}, superRefMismatches={}, stackRefMismatches={}",
+
+                      cmdPipeCounters.reads,
+                      cmdPipeCounters.bytesRead,
+                      cmdPipeCounters.timeouts,
+                      cmdPipeCounters.invalidHeaders,
+                      cmdPipeCounters.wordsSkipped,
+                      cmdPipeCounters.errorBuffers,
+                      cmdPipeCounters.superBuffers,
+                      cmdPipeCounters.stackBuffers,
+                      cmdPipeCounters.dsoBuffers,
+
+                      cmdPipeCounters.shortSuperBuffers,
+                      cmdPipeCounters.superFormatErrors,
+                      cmdPipeCounters.superRefMismatches,
+                      cmdPipeCounters.stackRefMismatches);
+
+        return 0;
+    }
+    catch (const std::runtime_error &e)
+    {
+        cerr << "mini-daq caught an exception: " << e.what() << endl;
+        return 1;
+    }
+    /*
+    catch (...)
+    {
+        cerr << "mini-daq caught an unknown exception" << endl;
+        return 1;
+    }
+    */
+
+    return 0;
+}

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -109,21 +109,61 @@ getStdinLine() {
 
 /// function to check that state transitions are legal:
 
+/** canBegin
+ * We can begine a run if the following conditions obtain:
+ * - The state in FRIBDAQRunState is Halted 
+ * - the Readout is finished - that is the workers have all
+ * rundown.
+ *    @param rdo - references the readout object.
+ *    @return bool - true if the run can be begun.
+ */
 static bool 
 canBegin(MVLCReadout& rdo) {
-    return true;
+    return (
+        ExtraRunState.s_runState == Halted &&
+        rdo.finished()
+    ); 
 }
+/**
+ * canEnd
+ *   We can end a run if the following conditions hold
+ *    - We are paused and the readout is finished.
+ *    - We are Active.
+ * @param rdo - the MVLCREadout object (referenced)
+ * @return bool - true if it's legal to end the run.
+ */
 static bool
 canEnd(MVLCReadout& rdo) {
-    return true;
+    return (
+        ExtraRunState.s_runState == Active ||
+        ((ExtraRunState.s_runState == Paused) && rdo.finished())
+    );
 }
+/**
+ * canPause
+ *     Determine if it is legal to pause the run.
+ * The run must be active for this to be legal:
+ * @param rdo - Readout object (unused for this but makes the calls the same).
+ * @return bool - true if the run can be paused.
+ */
 static bool
 canPause(MVLCReadout& rdo) {
-    return true;
+    return ExtraRunState.s_runState == Active;
 }
+/**
+ * canResume
+ *    Determine if resuming a run is legal.
+ * This is the case if we are Paused and finished.
+ * 
+ * @param rdo - the readout object.
+ * @return bool -True if legal.
+ */
 static bool
 canResume(MVLCReadout& rdo) {
-    return true;
+    return (
+        (ExtraRunState.s_runState == Paused)
+        && rdo.finished()
+    );
 }
 /////////////////////
 StackErrorCounters delta_counters(const StackErrorCounters &prev, const StackErrorCounters &curr)

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -58,7 +58,7 @@ static bool stdinPending() {
 
     timeval immediately = {tv_sec: 0, tv_usec: 0};
 
-    int status = select(STDIN_FILENO, &has_stdin, &empty, &empty, &immediately);
+    int status = select(STDIN_FILENO + 1, &has_stdin, &empty, &empty, &immediately);
 
     // errors are ok if errno is EINTR
 
@@ -728,9 +728,9 @@ int main(int argc, char *argv[])
 
             }
 
+            // If the run is active, dump the counters.
 
-
-            if (!opt_noPeriodicCounterDumps)
+            if (!opt_noPeriodicCounterDumps && (ExtraRunState.s_runState == Active)) 
             {
                 dump_counters(
                     cout,

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -124,8 +124,8 @@ canBegin(MVLCReadout& rdo) {
 static bool
 canEnd(MVLCReadout& rdo) {
     return (
-        ExtraRunState.s_runState == Active ||
-        ((ExtraRunState.s_runState == Paused) && rdo.finished())
+        (ExtraRunState.s_runState == Active) ||
+        (ExtraRunState.s_runState == Paused)
     );
 }
 /**

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <cstdlib>
 #include "command_parse.h"
+#include "parser_callbacks.h"
 #include "username.h"
 #include <CRingBuffer.h>
 #include <Exception.h>
@@ -42,24 +43,7 @@ struct MiniDaqCountersSnapshot
 };
 ///////////////////// added code to support command driven operation:
 
-/**
- *  This block of stuff is passed around to the parsers to provide
- * run state information:
- */
 
- typedef enum {
-    Active, Halted, Paused
-} FRIBState;
-
-struct FRIBDAQRunState {
-    unsigned s_runNumber;
-    std::string s_runTitle;
-    FRIBState s_runState;
-    CRingBuffer* s_pRing;
-FRIBDAQRunState() :
-    s_runState(Halted), s_pRing(nullptr) {}
-    
-} ;
 static FRIBDAQRunState ExtraRunState;
 
 

--- a/extras/fribdaq/src/parse_test.cc
+++ b/extras/fribdaq/src/parse_test.cc
@@ -1,0 +1,168 @@
+/** 
+ * @file parse_test.cc
+ * @brief test suite for command_parse's parseCommand function
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2005.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ */
+
+ /**
+  * @note I don't verify the error messages as that leads to fragile
+  * tests that need adjustment as error messages get 'better'.
+  */
+
+ #include "command_parse.h"
+ #include <gtest/gtest.h>
+
+
+ TEST(command_parse, EmptyInvalid) {
+    // Empty string gives invalid:
+    std::string line;
+    auto result = parseCommand(line);
+    ASSERT_EQ(result.s_command, INVALID);
+ }
+ TEST(command_parse, BadCommandInvalid) {
+    std::string line("Junky");
+    auto result = parseCommand(line);
+    ASSERT_EQ(result.s_command, INVALID);
+ }
+ TEST(command_Parse, BEGIN_OK) {
+    std::string line1("BEGIN");
+    std::string line2("begin");
+
+    auto result1 = parseCommand(line1);
+    auto result2 = parseCommand(line2);
+
+    ASSERT_EQ(result1.s_command, BEGIN);
+    ASSERT_EQ(result2.s_command, BEGIN);
+ }
+ TEST(command_parse, BEGIN_WS_TAIL) {
+    // whitespace tail is ok:
+
+    std::string line = ("begin     ");
+    auto result = parseCommand(line);
+    ASSERT_EQ(result.s_command, BEGIN);
+ }
+ TEST(command_parse, BEGIN_NOWS_TAIL) {
+    // Non whitespace tail is invalid
+
+    std::string line("begin run");
+    auto result = parseCommand(line);
+    ASSERT_EQ(result.s_command, INVALID);
+ }
+ // The other commands without an argumentn get teste in the 
+ // same code so we're not going to be quite as complete in the testing
+ // as we were for begin.
+
+ TEST(command_parse,  END) {
+    std::string line1("END");
+    std::string line2("end");
+
+    auto result1=parseCommand(line1);
+    auto result2=parseCommand(line2);
+
+    ASSERT_EQ(result1.s_command, END);
+    ASSERT_EQ(result2.s_command, END);
+ }
+
+ TEST(command_parse, PAUSE) {
+    std::string line1("pause");
+    std::string line2("PAUSE");
+
+    auto result1=parseCommand(line1);
+    auto result2=parseCommand(line2);
+
+    ASSERT_EQ(result1.s_command, PAUSE);
+    ASSERT_EQ(result2.s_command, PAUSE);
+ }
+
+ TEST(command_parse, RESUME) {
+    std::string line1("resume");
+    std::string line2("RESUME");
+
+    auto result1=parseCommand(line1);
+    auto result2=parseCommand(line2);
+
+    ASSERT_EQ(result1.s_command, RESUME);
+    ASSERT_EQ(result2.s_command, RESUME);
+ }
+
+ // Title must have a tail and that will be the s_stringarg
+
+ TEST(command_parse, TITLE_NO_TAIL) {
+    std::string line1("TITLE");    // Invalid.
+    std::string line2("TITLE     "); // also invalid...title cannot be only whitespace.
+
+    auto result1 = parseCommand(line1);
+    auto result2 = parseCommand(line2);
+
+    ASSERT_EQ(result1.s_command, INVALID);
+    ASSERT_EQ(result2.s_command, INVALID);
+ }
+
+ TEST(command_parse, TITLE_OK) {
+    std::string line1("TITLE This is a title string");
+    std::string line2("TITLE      This is a title string");  // Leading space is unimportant.
+
+    auto result1= parseCommand(line1);
+    auto result2 = parseCommand(line2);
+
+    ASSERT_EQ(result1.s_command, TITLE);
+    ASSERT_EQ(result1.s_stringarg, std::string("This is a title string"));
+
+    ASSERT_EQ(result2.s_command, TITLE);
+    ASSERT_EQ(result2.s_stringarg, std::string("This is a title string"));
+ }
+
+ // SETRUN must have a tail and it must be a single integer > 0.
+
+ TEST(command_parse, SETRUN_NOTAIL) {
+    std::string line1("SETRUN");
+    std::string line2("SETRUN    ");    // need more than whitespace.
+
+    auto result1 = parseCommand(line1);
+    auto result2 = parseCommand(line2);
+
+    ASSERT_EQ(result1.s_command, INVALID);
+    ASSERT_EQ(result2.s_command, INVALID);
+ }
+
+ // OK IF there's an integer > 0:
+
+ TEST(command_parse, SETRUN_OK) {
+    std::string line1("SETRUN 1");
+    std::string line2("setrun 2");
+
+    auto result1 = parseCommand(line1);
+    auto result2 = parseCommand(line2);
+
+    ASSERT_EQ(result1.s_command, SETRUN);
+    ASSERT_EQ(result2.s_command, SETRUN);
+
+    ASSERT_EQ(result1.s_intarg, 1);
+    ASSERT_EQ(result2.s_intarg, 2);
+ }
+
+ TEST(command_parse, SETRUN_BAD_NUMBER) {
+    // The run number must be > 0:
+
+    std::string line("setrun 0");
+
+    auto result = parseCommand(line);
+    ASSERT_EQ(result.s_command, INVALID);
+ }
+ TEST(command_parse, SETRUN_EXTRA_TAIL) {
+    // no tail after run numbger:
+
+    std::string line("setrun 1 bad");
+    auto result = parseCommand(line);
+    ASSERT_EQ(result.s_command, INVALID);
+ }

--- a/extras/fribdaq/src/parse_test.cc
+++ b/extras/fribdaq/src/parse_test.cc
@@ -5,7 +5,7 @@
  * 
  *
  *   This software is Copyright by the Board of Trustees of Michigan
- *   State University (c) Copyright 2005.
+ *   State University (c) Copyright 2025.
  *
  *   You may use this software under the terms of the GNU public license
  *   (GPL).  The terms of this license are described at:

--- a/extras/fribdaq/src/parser_callbacks.cc
+++ b/extras/fribdaq/src/parser_callbacks.cc
@@ -1,0 +1,227 @@
+/**
+ * @file parser_callbacks.cc
+ * @brief implementations of the event parser callbacks called in MVLCReadout objects.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+#include "parser_callbacks.h"
+#include <CRingBuffer.h>
+
+// A note:  We could use the unified format library but then we'd need to 
+// generate a ring item factory for a _specific_ FRIB/NSCLDAQ version but
+// we know that what we want to make are ring items for the version of
+// the software we were built against; so using that set is the best - I think.
+// Note that CDataFormatItems only came into being in NSCLDAQ-11.0.
+
+#include <CRingStateChangeItem.h>
+#include <CRingScalerItem.h>
+#include <CPhysicsEventItem.h>
+#include <CRingPhysicsEventCountItem.h>
+#include <CDataFormatItem.h>       // Requires NSCLDAQ-11.0 and higher.
+#include <stdint.h>
+#include <iostream>
+#include <vector>
+#include <time.h>
+
+
+
+static const int STACK_EVENT(1);
+static const int STACK_SCALER(2);
+static bool bad_stack_warning_given(false);
+
+////////////////////////////// private utilities ////////////////////////////////////////
+/**
+ *  submit_scaler
+ * 
+ *    Called to submit scaler data.  The assumption is that the payload for all
+ * of the pModuleDataList are 32 bit wide scalers.  We get the run time offset from
+ * the context.
+ * 
+ * @param context - the FRIBDAQRUnstate 
+ * @param pData   -  Pointer to the module list
+ * @param moduleCount - count of the number of modules in pData.
+ */
+static void
+submit_scaler(
+    FRIBDAQRunState* context, 
+    const mesytec::mvlc::readout_parser::ModuleData* pModuleDataList,
+    unsigned moduleCount
+) {
+    std::vector<uint32_t>  scalers;
+
+    // Marshall the data into the scaler vector from the module data:
+
+
+    for (int i = 0; i < moduleCount; i++) {
+        auto data = pModuleDataList->data;
+
+        // Size in u32s?
+
+        for (int j = 0; j < data.size; j++) {
+            scalers.push_back(data.data[j]);    // I'm to old fashioned to think of some fancy move.
+        }
+
+        pModuleDataList++;                   
+                // Next module.
+    }
+    // For now use a source-id of zero.  We'll need to add that to the context and set it up from parameters:
+
+    CRingScalerItem item (
+        0xffffffffffffffff, 0, 0,
+        context->s_lastScalerStopTime, context->s_runtime, time(nullptr), 
+        scalers, context->s_divisor
+    );
+    
+    item.commitToRing(*(context->s_pRing));
+
+    // Start/stop book keeping>
+
+    context->s_lastScalerStopTime = context->s_runtime;    // Start of next interval
+
+
+}
+/**
+ *  submit_event
+ *     Called when a physics event has been received from the parser.
+ *     The data from the modules are marshalled into CPhysicsEventItem which is
+ *     submitted to the ringbuffer
+ * 
+ * @param context - Poitner to the FRIBDAQRunState.
+ * @param pData   - Pointer to the module data
+ * @param moduleCount - number of module data items to process.
+ * 
+ */
+static void
+submit_event(
+    FRIBDAQRunState* context, const mesytec::mvlc::readout_parser::ModuleData* pModuleDataList,
+    unsigned moduleCount
+) {
+    // Size the event:
+
+    unsigned eventSize(0);                  // Will be in bytes:
+    for (int i=0; i < moduleCount; i++) {
+        eventSize += pModuleDataList[i].data.size * sizeof(uint32_t);
+    }
+    // Make the empty event and fill it.
+
+    CPhysicsEventItem event;
+    for ( int i  = 0; i < moduleCount; i++) {
+        uint32_t* pCursor = reinterpret_cast<uint32_t*>(event.getBodyCursor());
+        auto size = pModuleDataList->data.size;
+        memcpy(pCursor, pModuleDataList->data.data, size * sizeof(uint32_t));
+        pCursor += size;
+        event.setBodyCursor(pCursor);
+    }
+    event.updateSize();
+
+    event.commitToRing(*(context->s_pRing));
+    context->s_events++;                            // Update statistics.
+
+}
+
+
+/**
+ *  reset_statistics
+ *    Called on a begin run to reset some statistics in the run state:Active
+ * @param context - pointer to the FRIBDAQRunState item.
+ */
+static void
+reset_statistics(  FRIBDAQRunState* context )  {
+    context->s_events = 0;
+    context->s_lastScalerStopTime = 0;
+}
+////////////////////////////// Public entries ///////////////////////////////////
+/**
+ * stack_callback
+ *   What is done depends on the stack index.  If 1, dispatch to
+ *   submit_event(static), if 2, dispatch to submit_scaler(static).
+ *   For anything else emit a message and ignore the data.
+ */
+void
+stack_callback(
+    void* cd, 
+    int crate, int stack, 
+    const mesytec::mvlc::readout_parser::ModuleData* pModuleDataList,
+    unsigned moduleCount
+) {
+    // cd is really a pointer to FRIBDAQRuntState:
+
+    FRIBDAQRunState* context = reinterpret_cast<FRIBDAQRunState*>(cd);
+
+    // Dispatch to the appropriate marshalling/submitting function:
+
+    switch (stack) {
+        case STACK_EVENT:
+            submit_event(context, pModuleDataList, moduleCount);
+            break;
+        case STACK_SCALER:
+            submit_scaler(context, pModuleDataList, moduleCount);
+            break;
+        default:
+            if (!bad_stack_warning_given) {
+                std::cerr << "Unrecognized stack index: " << stack << std::endl;
+                std::cerr << "The FRIB/NSCLDAQ parser call back only recognize: \n";
+                std::cerr << "  " << STACK_EVENT << " - Physics trigger data\n";
+                std::cerr << "  " << STACK_SCALER << " - Timed scaler readout\n";
+                
+                std::cerr << "Data from this stack will be ignored.  Check your crate configuration.\n";
+                bad_stack_warning_given = true;      // Don't flook output/error.
+            }
+    }
+}
+
+/**
+ *  Called on a system event.  Much of the stuff we need for this is in the context
+ * struct.
+ */
+void system_event_callback(
+    void* cd,
+    int crateIndex, const mesytec::mvlc::u32* header, mesytec::mvlc::u32 size
+) {
+    FRIBDAQRunState* context = reinterpret_cast<FRIBDAQRunState*>(cd);
+
+    // We only care about the run state transitions:
+    uint16_t itemType;
+
+    // Chose the right type of item:
+
+
+    switch (mesytec::mvlc::system_event::extract_subtype(*header))
+    {
+        case mesytec::mvlc::system_event::subtype::BeginRun:
+            itemType = BEGIN_RUN;
+            reset_statistics(context);
+            break;
+        case mesytec::mvlc::system_event::subtype::EndRun:
+            itemType= END_RUN;
+            break;
+        case mesytec::mvlc::system_event::subtype::Pause:
+            itemType = PAUSE_RUN;
+            break;
+        case mesytec::mvlc::system_event::subtype::Resume:
+            itemType = RESUME_RUN;  
+            break;
+        default:
+            return;                                // Silently ignore all other types.
+    }
+    // Let's emit a format item prior to all of these...
+
+    CDataFormatItem fmtItem;
+    fmtItem.commitToRing(*context->s_pRing);
+
+    CRingStateChangeItem item(
+        0xffffffff, 0, 0, 
+        itemType, context->s_runNumber, context->s_runtime, time(nullptr), context->s_runTitle, context->s_divisor
+    );
+    item.commitToRing(*context->s_pRing);
+}

--- a/extras/fribdaq/src/parser_callbacks.cc
+++ b/extras/fribdaq/src/parser_callbacks.cc
@@ -35,8 +35,8 @@
 
 
 
-static const int STACK_EVENT(1);
-static const int STACK_SCALER(2);
+static const int STACK_EVENT(0);
+static const int STACK_SCALER(1);
 static bool bad_stack_warning_given(false);
 
 ////////////////////////////// private utilities ////////////////////////////////////////

--- a/extras/fribdaq/src/parser_callbacks.h
+++ b/extras/fribdaq/src/parser_callbacks.h
@@ -41,8 +41,16 @@ struct FRIBDAQRunState {
     std::string s_runTitle;
     FRIBState s_runState;
     CRingBuffer* s_pRing;
-FRIBDAQRunState() :
-    s_runState(Halted), s_pRing(nullptr) {}
+    // THe statistics get initialized by begin run state changes.
+    unsigned     s_events;     // Number of accepted events.
+    unsigned     s_runtime;    // Run offset.
+    unsigned     s_lastScalerStopTime;
+    unsigned     s_divisor;    // Offset divisor. 
+FRIBDAQRunState() : 
+    s_runNumber(0),            // If never set.
+    s_runState(Halted), s_pRing(nullptr),
+    s_divisor(1000)           // Timing in milliseconds
+    {}
     
 };
  
@@ -62,7 +70,7 @@ FRIBDAQRunState() :
 void stack_callback(
     void* cd, 
     int crate, int stack, 
-    mesytec::mvlc::readout_parser::ModuleData* pModuleDataList,
+    const mesytec::mvlc::readout_parser::ModuleData* pModuleDataList,
     unsigned moduleCount
 );
 

--- a/extras/fribdaq/src/parser_callbacks.h
+++ b/extras/fribdaq/src/parser_callbacks.h
@@ -49,7 +49,7 @@ struct FRIBDAQRunState {
 FRIBDAQRunState() : 
     s_runNumber(0),            // If never set.
     s_runState(Halted), s_pRing(nullptr),
-    s_divisor(1000)           // Timing in milliseconds
+    s_divisor(1)           // Timing in seconds.
     {}
     
 };

--- a/extras/fribdaq/src/parser_callbacks.h
+++ b/extras/fribdaq/src/parser_callbacks.h
@@ -49,7 +49,7 @@ struct FRIBDAQRunState {
 FRIBDAQRunState() : 
     s_runNumber(0),            // If never set.
     s_runState(Halted), s_pRing(nullptr),
-    s_divisor(1)           // Timing in seconds.
+    s_divisor(1000)           // Timing in seconds.
     {}
     
 };

--- a/extras/fribdaq/src/parser_callbacks.h
+++ b/extras/fribdaq/src/parser_callbacks.h
@@ -1,0 +1,82 @@
+/**
+ * @file parser_callbacks.h
+ * @brief interfaces for the event parser callbacks called in MVLCReadout objects.
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ * @note - this file is private to fribdaq's readout and won't be installed.
+ */
+
+ #ifndef PARSER_CALLBACKS_H
+ #define PARSER_CALLBACKS_H
+
+ #include <mesytec-mvlc/mvlc_readout_parser.h>
+
+
+ // Forward type definitions:
+
+ class CRingBuffer;
+
+ /**
+ *  This block of stuff is passed around to the parsers to provide
+ * run state information:
+ */
+
+ typedef enum {
+    Active, Halted, Paused
+} FRIBState;
+
+
+
+struct FRIBDAQRunState {
+    unsigned s_runNumber;
+    std::string s_runTitle;
+    FRIBState s_runState;
+    CRingBuffer* s_pRing;
+FRIBDAQRunState() :
+    s_runState(Halted), s_pRing(nullptr) {}
+    
+};
+ 
+/**
+ *  This is called whenver stack data is processed by the parser.  We 
+ * generatwe the appropriate ring item (see stack below) and insert it into
+ * the ringbuffer.
+ * @param cd - Actually a pointer to an FRIBDAQRunState object.
+ * @param crate - Index of the VME crate being read out. We only support one for now.
+ * @param stack - Index of the stack these data come from.  We support:
+ *     - 1  - Data triggered by NIM input 1.  This is physics data.
+ *     - 2  - Data triggered periodically.  This is scaler data.
+ * @param pModuleDataList - pointer to the parsed data from the module.
+ * @param moduleCount - number of parsed modules in the moduleDataList.
+ * 
+ */
+void stack_callback(
+    void* cd, 
+    int crate, int stack, 
+    mesytec::mvlc::readout_parser::ModuleData* pModuleDataList,
+    unsigned moduleCount
+);
+
+/**
+ * This is called when a system event occurs.  We care about run transitions 
+ * and then add the appropriate run transition ring item to the output ringbuffer.
+ * 
+ * @param cd - client data, this is actually a pointer to an FRIBDAQRunState object.
+ * @param crateIndex - crate number from which this came, we only support one crate
+ * @param header - pointer to data associated with the state transition.
+ * @param size   - Size of the header.
+ */
+void system_event_callback(
+    void* cd,
+    int crateIndex, const mesytec::mvlc::u32* header, mesytec::mvlc::u32 size
+);
+ #endif

--- a/extras/fribdaq/src/username.cc
+++ b/extras/fribdaq/src/username.cc
@@ -1,0 +1,39 @@
+/**
+ * @file username.cc
+ * @brief Provides a utility function to return the UNIX/Linux usrename.alignas
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2025.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ */
+#include "username.h"
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <stdexcept>
+
+/**
+ *  getUsername
+ *    Note that we don't use the getlogin family because those are
+ * observed to fail under linux on WSL.   Using getppwuid does work
+ * however.alignas
+ * @return std::string - The logged in user name
+ * 
+ */
+std::string
+getUsername() {
+    uid_t uid = getuid();     // manpage sys this never fails.
+    struct passwd *pw = getpwuid(uid);
+    if (pw) {
+        return std::string(pw->pw_name);
+    } else {
+        throw std::runtime_error("getpwuid failed in getUsername");
+    }
+}

--- a/extras/fribdaq/src/username.h
+++ b/extras/fribdaq/src/username.h
@@ -1,0 +1,23 @@
+/**
+ * @file username.h
+ * @brief Provides a utility function to return the UNIX/Linux usrename.alignas
+ * @author Ron Fox <fox @ frib dot msu dot edu>
+ * 
+ *
+ *   This software is Copyright by the Board of Trustees of Michigan
+ *   State University (c) Copyright 2005.
+ *
+ *   You may use this software under the terms of the GNU public license
+ *   (GPL).  The terms of this license are described at:
+ *
+ *    http://www.gnu.org/licenses/gpl.txt
+ * 
+ */
+#ifndef USERNAME_H
+#define USERNAME_H
+
+#include <string>
+
+std::string getUsername();
+
+#endif

--- a/extras/mini-daq/src/mdpp16-readout-example1.cc
+++ b/extras/mini-daq/src/mdpp16-readout-example1.cc
@@ -182,7 +182,7 @@ class ReadoutHelper
 };
 
 void handle_event_data(void *userContext, int crateIndex, int eventIndex,
-                       const ModuleData *moduleDataList, unsigned moduleCount)
+                       const readout_parser::ModuleData *moduleDataList, unsigned moduleCount)
 {
     spdlog::info("handle_event_data: {} {}", fmt::ptr(moduleDataList), moduleCount);
     for (unsigned mi=0; mi<moduleCount; ++mi)

--- a/extras/mini-daq/src/mini_daq_main.cc
+++ b/extras/mini-daq/src/mini_daq_main.cc
@@ -35,13 +35,13 @@ StackErrorCounters delta_counters(const StackErrorCounters &prev, const StackErr
                    std::begin(result.stackErrors),
                    util::delta_map<ErrorInfoCounts>);
 
-    result.nonErrorFrames = calc_delta0(curr.nonErrorFrames, prev.nonErrorFrames);
-    result.nonErrorHeaderCounts = delta_map(prev.nonErrorHeaderCounts, curr.nonErrorHeaderCounts);
+    result.nonErrorFrames = util::calc_delta0(curr.nonErrorFrames, prev.nonErrorFrames);
+    result.nonErrorHeaderCounts = util::delta_map(prev.nonErrorHeaderCounts, curr.nonErrorHeaderCounts);
 
     return result;
 }
 
-#define CALC_DELTA0(member) result.member = calc_delta0(curr.member, prev.member)
+#define CALC_DELTA0(member) result.member = util::calc_delta0(curr.member, prev.member)
 
 ReadoutWorker::Counters delta_counters(const ReadoutWorker::Counters &prev, const ReadoutWorker::Counters &curr)
 {
@@ -59,7 +59,7 @@ ReadoutWorker::Counters delta_counters(const ReadoutWorker::Counters &prev, cons
     std::transform(std::begin(prev.stackHits), std::end(prev.stackHits),
                    std::begin(curr.stackHits),
                    std::begin(result.stackHits),
-                   calc_delta0<size_t>);
+                   util::calc_delta0<size_t>);
 
     // TODO eth::PipeStats
     // TODO ListfileWriterCounters
@@ -328,7 +328,7 @@ int main(int argc, char *argv[])
 
         // positional args
         | lyra::arg(opt_crateConfig, "crateConfig")
-            ("crate config yaml file").required()
+            ("crate config YAML or JSON file").required()
 
         | lyra::arg(opt_secondsToRun, "secondsToRun")
             ("duration the DAQ should run in seconds").optional()
@@ -365,15 +365,6 @@ int main(int argc, char *argv[])
     if (opt_logTrace)
         set_global_log_level(spdlog::level::trace);
 
-
-    std::ifstream inConfig(opt_crateConfig);
-
-    if (!inConfig.is_open())
-    {
-        cerr << "Error opening crate config " << argv[1] << " for reading." << endl;
-        return 1;
-    }
-
     try
     {
         auto timeToRun = std::chrono::seconds(opt_secondsToRun);
@@ -382,11 +373,11 @@ int main(int argc, char *argv[])
 
         try
         {
-            crateConfig = crate_config_from_yaml(inConfig);
+            crateConfig = crate_config_from_file(opt_crateConfig);
         }
         catch (const std::runtime_error &e)
         {
-            cerr << "Error parsing CrateConfig: " << e.what() << endl;
+            cerr << fmt::format("Error loading CrateConfig from '{}': {}\n", opt_crateConfig, e.what());
             return 1;
         }
 
@@ -515,7 +506,7 @@ int main(int argc, char *argv[])
         }
 
         MiniDaqCountersUpdate counters;
-        Stopwatch sw;
+        util::Stopwatch sw;
 
         while (!rdo.finished())
         {

--- a/src/mesytec-mvlc/mesytec-mvlc.h
+++ b/src/mesytec-mvlc/mesytec-mvlc.h
@@ -30,6 +30,7 @@
 
 #include "cpp_compat.h"
 #include "event_builder.h"
+#include "event_builder2.hpp"
 #include "git_version.h"
 #include "mvlc_blocking_data_api.h"
 #include "mvlc_command_builders.h"

--- a/src/mesytec-mvlc/mvlc_impl_eth.h
+++ b/src/mesytec-mvlc/mvlc_impl_eth.h
@@ -108,6 +108,7 @@ class MESYTEC_MVLC_EXPORT Impl: public MVLCBasicInterface, public MVLC_ETH_Inter
 
         // Returns the host/IP string given to the constructor.
         std::string getHost() const { return m_host; }
+        std::string getRemoteAddress() const { return getHost(); }
 
         sockaddr_in getCmdSockAddress() const { return m_cmdAddr; }
         sockaddr_in getDataSockAddress() const { return m_dataAddr; }
@@ -166,6 +167,10 @@ class MESYTEC_MVLC_EXPORT Impl: public MVLCBasicInterface, public MVLC_ETH_Inter
 // Given the previous and current packet numbers returns the number of lost
 // packets in-between, taking overflow into account.
 s32 MESYTEC_MVLC_EXPORT calc_packet_loss(u16 lastPacketNumber, u16 packetNumber);
+
+// Sends an EthDelay (0x0207) command packet through the given socket.
+// No response data; the MVLC delay port is write only.
+std::error_code MESYTEC_MVLC_EXPORT send_delay_command(int delaySock, u16 delay_us);
 
 }
 

--- a/src/mesytec-mvlc/mvlc_readout_config.h
+++ b/src/mesytec-mvlc/mvlc_readout_config.h
@@ -75,6 +75,14 @@ StackCommandBuilder MESYTEC_MVLC_EXPORT stack_command_builder_from_yaml_file(con
 std::string MESYTEC_MVLC_EXPORT to_json(const CrateConfig &crateConfig);
 CrateConfig MESYTEC_MVLC_EXPORT crate_config_from_json(const std::string &json);
 
+// Wrapper around the from_yaml/from_json functions.
+// - data contains the raw YAML or JSON data.
+// - format is either "yaml" or "json".
+// Throws on error
+CrateConfig MESYTEC_MVLC_EXPORT crate_config_from_data(const std::string &data, const std::string &format);
+CrateConfig MESYTEC_MVLC_EXPORT crate_config_from_file(const std::string &filename);
+
+// StackCommandBuilder serialization
 std::string MESYTEC_MVLC_EXPORT to_json(const StackCommandBuilder &sb);
 StackCommandBuilder MESYTEC_MVLC_EXPORT stack_command_builder_from_json(const std::string &json);
 

--- a/src/mesytec-mvlc/mvlc_readout_parser.h
+++ b/src/mesytec-mvlc/mvlc_readout_parser.h
@@ -140,7 +140,8 @@ struct ReadoutParserCallbacks
     // Parameters are:
     // - userContext as passed to make_readout_parser()
     // - crateIndex as passed to make_readout_parser(), starts from 0
-    // - eventIndex starting from 0
+    // - eventIndex starting from 0. This is the originating readout stack
+    //   number - 1 (stack 0 is used for interactive commands).
     // - moduleDataList: pointer to ModuleData structures
     // - number of ModuleData structures stored in moduleDataList
 


### PR DESCRIPTION
Based on the current 'dev' branch of mesytec-mvlc.

- Attempt to no crash when calling ReadoutWorker::start() multiple times.
- Make Pause/Resume events immediately visible in the output data stream.