### PR TITLE
Issue #12 - Remove command options we don't need.

### DIFF
--- a/extras/fribdaq/Readme.md
+++ b/extras/fribdaq/Readme.md
@@ -20,14 +20,15 @@ If you are using the FRIB containerized environment this will have been installe
 
 ### Using fribdaq-readout
 
-```fribdaq-readout``` supports the options supported by minidaq
+```fribdaq-readout``` supports a reduced set of the minidaq options.  Several options that don't make
+sense in the context of the FRIB/NSCLDAQ environment have been removed.
 (use --help to list the full option set and short form documentation)  with the added options:
 
 * ```--ring ringname```  selects the name of the ring buffer to which the data should be written.  This is a ring name not a URI, as only local ringbuffers can be written to.  If the option is not provided, this defaults to the name of the logged in user.
 * ```--sourceid id``` When used in a larger system that builds events from several sources using the FRIB/NSCLDAQ event builder, this specifies the unique integer source id  that will be used to identify fragments from this data source.   If not provided, this defaults to 0.
 * ```--timestamp-library``` When used with a larger system that builds events from several sources using the FRIB/NSCLDAQ event builder, this specifies a shared library file which includes code to extract timestamps from the raw event data.   If not provided, the body headers required to build events will not be included in the ```PHYSCIS_EVENT``` items.
 
-Following all options on the command line, a single positional parameter provides the name of a .yaml configuration file that was either exported from ```mdaq``` or produced using the FRIBDA/NSCLDAQ configuration tools (to be included in versions 12.2 of FRIB/NSCLDAQ).
+Following all options on the command line, a single positional parameter provides the name of a .yaml configuration file that was either exported from ```mdaq``` or produced using the FRIBDA/NSCLDAQ configuration tools mvlcgenerate in FRIB/NSCLDAQ version 12.2 and later.
 
 ####  fribdaq-readout commands
 

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -438,38 +438,22 @@ int main(int argc, char *argv[])
         | lyra::opt(opt_mvlcUSBSerial, "serial")
             ["--mvlc-usb-serial"] ("connect to the mvlc with the given usb serial number (overrides CrateConfig)")
 
-        // listfile
-        | lyra::opt(opt_noListfile)
-            ["--no-listfile"] ("do not write readout data to a listfile (data will not be recorded)")
-
-        | lyra::opt(opt_overwriteListfile)
-            ["--overwrite-listfile"] ("overwrite an existing listfile")
-
-        | lyra::opt(opt_listfileOut, "listfileName")
-            ["--listfile"] ("filename of the output listfile (e.g. run001.zip)")
-
-        | lyra::opt(opt_listfileCompressionType, "type")
-            ["--listfile-compression-type"].choices("zip", "lz4") ("'zip' or 'lz4'")
-
-        | lyra::opt(opt_listfileCompressionLevel, "level")
-            ["--listfile-compression-level"] ("compression level to use (for zip 0 means no compression)")
-
+        // listfile options removed.
+        
         // logging
-        | lyra::opt(opt_printReadoutData)
-            ["--print-readout-data"]("log each word of readout data (very verbose!)")
-
-        | lyra::opt(opt_noPeriodicCounterDumps)
-            ["--no-periodic-counter-dumps"]("do not periodcally print readout and parser counters to stdout")
-
         | lyra::opt(opt_initOnly)
             ["--init-only"]("run the DAQ init sequence and exit")
 
         | lyra::opt(opt_ignoreInitErrors)
             ["--ignore-vme-init-errors"]("ignore VME errors during the DAQ init sequence")
+
+        // FRIBDAQ Speciic options.
+
         | lyra::opt(opt_ringBufferName, "ring")["--ring"]("ring buffer name")
         | lyra::opt(opt_sourceid, "sourceid")["--sourceid"]("Event builder source id")
         | lyra::opt(opt_timestampdll, "dll")["--timestamp-library"]("Time stamp shared library file")
         | lyra::opt(opt_initscript, "initscript")["--init-script"]("Tcl initialization script")
+        
         // logging
         | lyra::opt(opt_logDebug)["--debug"]("enable debug logging")
         | lyra::opt(opt_logTrace)["--trace"]("enable trace logging")
@@ -613,22 +597,17 @@ int main(int argc, char *argv[])
             }
         }
         //
-        // Listfile setup
+        // Listfile setup : Never writing it.
         //
-        if (opt_listfileOut.empty())
-            opt_listfileOut = util::basename(opt_crateConfig) + ".zip";
+       
 
         ListfileParams listfileParams =
         {
-            .writeListfile = !opt_noListfile,
-            .filepath = opt_listfileOut,
-            .overwrite = opt_overwriteListfile,
-
-            .compression = (opt_listfileCompressionType == "lz4"
-                            ? ListfileParams::Compression::LZ4
-                            : ListfileParams::Compression::ZIP),
-
-            .compressionLevel = opt_listfileCompressionLevel,
+            .writeListfile = false,
+            .filepath = "",
+            .overwrite = false,
+            .compression = ListfileParams::Compression::LZ4,
+            .compressionLevel = 0,
 
         };
 
@@ -643,7 +622,8 @@ int main(int argc, char *argv[])
 
         //
         // readout object
-        //
+
+        
 
         auto rdo = make_mvlc_readout(
             mvlc,


### PR DESCRIPTION
* This removes a bunch of options that I don't think are meaningful in FRIB/NSCLDAQ.
*  Documentation updated to:
    -  Indicate that only a reduced set of command options are supported.
    -  Explicitly mention the mvlcgenerate tool in FRIB/NSCLDAQ-12.2 and later.