### PR TITLE
Rfoxkendo/issue10

### DIFF
--- a/extras/fribdaq/Readme.md
+++ b/extras/fribdaq/Readme.md
@@ -27,6 +27,11 @@ sense in the context of the FRIB/NSCLDAQ environment have been removed.
 * ```--ring ringname```  selects the name of the ring buffer to which the data should be written.  This is a ring name not a URI, as only local ringbuffers can be written to.  If the option is not provided, this defaults to the name of the logged in user.
 * ```--sourceid id``` When used in a larger system that builds events from several sources using the FRIB/NSCLDAQ event builder, this specifies the unique integer source id  that will be used to identify fragments from this data source.   If not provided, this defaults to 0.
 * ```--timestamp-library``` When used with a larger system that builds events from several sources using the FRIB/NSCLDAQ event builder, this specifies a shared library file which includes code to extract timestamps from the raw event data.   If not provided, the body headers required to build events will not be included in the ```PHYSCIS_EVENT``` items.
+* ```--convert-tcl``` Requires a setup version of NSCLDAQ (```DAQBIN``` environment variable defined) with ```mvlcgenerate``` in ```DAQBIN```.  If used, the configuration file is treate as a Tcl script describing the experimewnt suitable as input for ```mvlcgenerate```.   At startup, and the prior to the beginning of each run, ```mvlcgenerate``` is run to convert that file to a yaml crate configitation file.  The converted file is then
+used as the configuration file.  The converted filename is generated from the configuration file name prepending it with a ```.``` to make it a hidden file and appending ```.yaml```.  E.g the configuration file 
+```daqconfig.tcl``` will be converted to ```.daqconfig.tcl.yaml```.
+* ```--template``` this option only makes sense when ```--convert-tcl``` is used. The parameter to this option will be used by ```mvlcgenerate``` as the template yaml file into which the configuration is converted.  This
+supports the use of non-default trigger conditions.  See the ```--template``` option on the FRIB/NSCLDAQ documentation for ```mvlcgenerate```.
 
 Following all options on the command line, a single positional parameter provides the name of a .yaml configuration file that was either exported from ```mdaq``` or produced using the FRIBDA/NSCLDAQ configuration tools mvlcgenerate in FRIB/NSCLDAQ version 12.2 and later.
 

--- a/extras/fribdaq/src/BeginCommand.cc
+++ b/extras/fribdaq/src/BeginCommand.cc
@@ -27,6 +27,11 @@
 
 using mesytec::mvlc::MVLCReadout;
 
+// for translating tcl -> yaml
+
+
+extern void regenerateCrateFileIfNeeded(const std::string& crateFile);
+
 /**
  * constructor
  *    @param interp - encapsulated Tcl interpreter on which the command is registered.
@@ -79,6 +84,7 @@ BeginCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& objv)
 
     if (canBegin(*m_pReadout, *m_pRunState)) {
         try {
+            regenerateCrateFileIfNeeded(m_configFileName);
             setConfiguration();                // Update the configuration.
             // Set title and runn um if can:
 

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -607,6 +607,7 @@ int main(int argc, char *argv[])
             opt_crateConfig = dirname(const_cast<char*>(tclFile.c_str()));   // Posix won't change tclFile.
             opt_crateConfig += "/.";
             opt_crateConfig += basename(const_cast<char*>(tclFile.c_str())); // Posix won't change tclFile.
+            opt_crateConfig += ".yaml";
             yamlTemplate = opt_templateFile;
 
             generateCrateFile(opt_crateConfig, mvlcgenerate, opt_templateFile, tclFile);

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -424,6 +424,13 @@ int main(int argc, char *argv[])
     int opt_controlServerPort = -1;
     std::string opt_controlInitScript ="";
 
+    // Isue #10 flags to support regeneration of
+    // the yaml from a tcl using mvlcgenerate
+    //  
+
+    bool opt_regenerate = false;        // True to regenerate.
+    std::string opt_templateFile = "";       // Alternate template file.
+
     auto cli
         = lyra::help(opt_showHelp)
 
@@ -460,10 +467,12 @@ int main(int argc, char *argv[])
         // logging
         | lyra::opt(opt_logDebug)["--debug"]("enable debug logging")
         | lyra::opt(opt_logTrace)["--trace"]("enable trace logging")
-        
+        | lyra::opt(opt_regenerate)["--convert-tcl"]("Crate crate yaml from FRIB/NSCLDAQ .tcl file")
+        | lyra::opt(opt_templateFile, "YamlTemplate")["--template"]("With --convert-tcl specify alternate template file")
+
         // positional args
         | lyra::arg(opt_crateConfig, "crateConfig")
-            ("crate config yaml file").required()        
+            ("crate config yaml/tcl file").required()        
         ;
 
     auto cliParseResult = cli.parse({ argc, argv });

--- a/extras/fribdaq/src/fribdaq_readout.cc
+++ b/extras/fribdaq/src/fribdaq_readout.cc
@@ -31,6 +31,7 @@
 
 #include <mesytec-mvlc/mesytec-mvlc.h>
 #include <lyra/lyra.hpp>
+#include <libgen.h>
 
 /* Issue #5 - better command handling - use Tcl event driven input interpreter */
 #include "BeginCommand.h"
@@ -66,13 +67,102 @@ struct MiniDaqCountersSnapshot
 static const char* timestampFunctionName = "extract_timestamp";
 static FRIBDAQRunState ExtraRunState;
 
+// Used in the case --regenerate is enabled.
+
+static std::string tclFile;       // Name of the tcl file to process.
+static bool regenerate;           // regeneration is enabled.
+static std::string mvlcgenerate;  // translated path to $DAQBIN/mvlcgenerate
+static std::string yamlTemplate;  // Yaml template if not default.
+
 
 /**
- * This struct is passed to the exti handler.  It needs all that stuff to 
- * clean up prior to the actual exit.alignas
+ * This struct is passed to the exit handler.  It needs all that stuff to 
+ * clean up prior to the actual exit.
  * 
  */
+struct ExitInfo {
+    MVLCReadout*  s_readout;
+    MVLC*         s_mvlc;
+    CrateConfig*  s_config;
 
+} exitinfo;
+
+/**
+ * This function crates a crate file given
+ * @param dest         - path to the output file.
+ * @param mvlcgenerate - the path to the mvlcgenerate translator program.
+ * @param templateFile - Path to the yaml template, or "" if the default template should be used.
+ * @param tclFile      - Path to the 'daqconfig.tcl' file to translate.
+ * 
+ *  Exits on error.
+ */
+static void 
+generateCrateFile(
+    const std::string& dest, const std::string& mvlcgenerate, 
+    const std::string templateFile, const std::string tclFile) {
+    
+    // Construct the command for 'system'
+
+    std::stringstream strCommand;
+    strCommand << mvlcgenerate << " --output=" << dest << " ";
+    if (templateFile != "") {
+        strCommand << "--template=" << templateFile << " ";
+    }
+    strCommand << tclFile;
+    std::string command = strCommand.str();
+
+    if (system(command.c_str())) {
+        std::cerr << "Unable to generate the crate file from a daqconfig Tcl file\n";
+        exit(EXIT_FAILURE);
+    }
+}
+/**
+ *  This function can be called by e.g. begin run to regenerate the crate file if that's
+ *  supposed to happen.
+ * 
+ * @param crateFile - name of crate file.
+ */
+void 
+regenerateCrateFileIfNeeded(const std::string& crateFile) {
+    if (regenerate) {
+        generateCrateFile(crateFile, mvlcgenerate, yamlTemplate, tclFile);
+    }
+}
+/**
+ *  mvlcGeneratePath
+ *     @return std::string - path to $DAQBIN/mvlcgenerate
+ *     @retval "" if there's no such program or it's not executable.
+ */
+static std::string
+mvlcGeneratePath() {
+    // Translate DAQBIN - must translate else "".
+
+    const char* bindir = std::getenv("DAQBIN");
+    if (!bindir) return std::string("");
+
+
+    // Construct the full name:
+
+    std::string path(bindir);
+    path += "/mvlcgenerate";
+
+    // Must be executable:
+    
+    if (access(path.c_str(), X_OK)) {
+        return std::string("");
+    }
+
+    return path;
+}
+/**
+ * foundMvlcGenerate
+ *     @return bool Returns true if there's a $DAQBIN/mvlcgenerate file.
+ */
+static bool
+foundMvlcGenerate() {
+    auto path = mvlcGeneratePath();
+    return path  != "";
+}
 /**
  * loadTimestampExtrctor
  *   Loads a shared object that contains a function named 'extract_timestamp' that better be a 
@@ -183,12 +273,7 @@ struct MiniDaqCountersUpdate
     MiniDaqCountersSnapshot curr;
     std::chrono::milliseconds dt;
 };
-struct ExitInfo {
-    MVLCReadout*  s_readout;
-    MVLC*         s_mvlc;
-    CrateConfig*  s_config;
 
-} exitinfo;
 void dump_counters2(
     std::ostream &out,
     const MiniDaqCountersSnapshot &prev,
@@ -511,7 +596,22 @@ int main(int argc, char *argv[])
     if (opt_logTrace)
         set_global_log_level(spdlog::level::trace);
 
+    // if we're converting we need to have $DAQBIN/mvlcgenerate
+    if (opt_regenerate) {
+        if (!foundMvlcGenerate()) {
+            std::cerr << "To use the --regenerate option, you must run a daqsetup.sh for a version of FRIB/NSCLDAQ with $DAQBIN/mvlcgenerate built\n";
+            std::exit(EXIT_FAILURE);
+        } else {
+            mvlcgenerate = mvlcGeneratePath();
+            tclFile = opt_crateConfig;
+            opt_crateConfig = dirname(const_cast<char*>(tclFile.c_str()));   // Posix won't change tclFile.
+            opt_crateConfig += "/.";
+            opt_crateConfig += basename(const_cast<char*>(tclFile.c_str())); // Posix won't change tclFile.
+            yamlTemplate = opt_templateFile;
 
+            generateCrateFile(opt_crateConfig, mvlcgenerate, opt_templateFile, tclFile);
+        }
+    }
     std::ifstream inConfig(opt_crateConfig);
 
     if (!inConfig.is_open())


### PR DESCRIPTION
Resolve issue #10 - Support directly using inputs to mvlcgenerate  (tcl configuration files), auto generate the yaml usiung $DAQBIN/mvlcgenerate:

* add --convert-tcl option to convert yadayad.tcl -> .yadayada.tcl.yaml and use that for the configuration (prior to the start of each run),
* Add --template _filename_ option to specify a user created yaml template file for thye converion (supporting "non standard' trigger definitions for the event stack).,